### PR TITLE
오늘 근무자 연동

### DIFF
--- a/controllers/scheduleController.js
+++ b/controllers/scheduleController.js
@@ -147,3 +147,29 @@ exports.getConfirmedSchedulesByGroup = async (req, res) => {
     res.status(500).json({ success: false, message: '서버 오류' });
   }
 };
+
+// 오늘 근무자 정보 조회
+exports.getTodayWorkers = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+    if (!groupId) {
+      return res.status(400).json({ 
+        success: false, 
+        message: 'groupId가 필요합니다.' 
+      });
+    }
+
+    const result = await scheduleService.getTodayWorkers(groupId);
+    res.status(200).json({ 
+      success: true, 
+      data: result.workers,
+      message: result.message
+    });
+  } catch (error) {
+    console.error('❌ 오늘 근무자 정보 조회 실패:', error);
+    res.status(500).json({ 
+      success: false, 
+      message: error.message || '서버 오류' 
+    });
+  }
+};

--- a/routes/scheduleRoutes.js
+++ b/routes/scheduleRoutes.js
@@ -13,4 +13,8 @@ router.get('/:scheduleId/unavailable', authenticate, scheduleController.getUnava
 router.get('/:scheduleId/unavailable/all', authenticate, scheduleController.getUnavailableByScheduleId);
 router.patch('/:scheduleId/confirm', authenticate, scheduleController.confirmSchedule);
 router.get('/confirmed', authenticate, scheduleController.getConfirmedSchedulesByGroup);
+
+// 🔹 오늘 근무자 정보 조회
+router.get('/group/:groupId/today', authenticate, scheduleController.getTodayWorkers);
+
 module.exports = router;


### PR DESCRIPTION
# 오늘 근무자 정보 조회 API 추가

## 변경사항
- 오늘 근무자 정보를 조회하는 API 엔드포인트 추가
- 근무자 목록 정렬 기능 추가
- 에러 처리 및 응답 메시지 개선

## 주요 기능
1. API 엔드포인트: `GET /api/schedules/group/:groupId/today`
   - 특정 그룹의 오늘 근무자 정보 조회
   - Firebase 인증 토큰 필요

2. 응답 형식
```json
{
  "success": true,
  "data": [
    { "worker_name": "worker1" },
    { "worker_name": "worker2" }
  ],
  "message": "오늘 근무자 정보를 성공적으로 가져왔습니다."
}
```

3. 에러 처리
   - 스케줄이 없는 경우: "오늘 확정된 스케줄이 없습니다."
   - 근무자가 없는 경우: "오늘 근무자가 없습니다."
   - 서버 오류: "근무자 정보를 가져오는 중 오류가 발생했습니다."

## 개선사항
- 근무자 이름 알파벳 순 정렬
- 상세한 에러 메시지 제공

## 테스트 항목
- [ ] API 엔드포인트 정상 작동
- [ ] 에러 메시지 정상 표시

